### PR TITLE
ensure serverSideTranslations do not rely on a global state

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "next-i18next",
-  "version": "14.0.3",
+  "name": "@intuita-inc/next-i18next",
+  "version": "14.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "next-i18next",
-      "version": "14.0.3",
+      "name": "@intuita-inc/next-i18next",
+      "version": "14.0.4",
       "funding": [
         {
           "type": "individual",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "next-i18next",
-  "version": "14.0.3",
-  "repository": "git@github.com:i18next/next-i18next.git",
+  "name": "@intuita-inc/next-i18next",
+  "version": "14.0.4",
+  "repository": "git@github.com:intuita-inc/next-i18next.git",
   "author": "i18next",
   "funding": [
     {

--- a/src/serverSideTranslations.test.tsx
+++ b/src/serverSideTranslations.test.tsx
@@ -504,7 +504,8 @@ describe('serverSideTranslations', () => {
 
     it('does thrown an error with fallbackLng (as function)', async () => {
       const config: UserConfig = {
-        fallbackLng: (code: string) => (code === 'de-AT' ? 'de' : 'en'),
+        fallbackLng: (code: string) =>
+          code === 'de-AT' ? 'de' : 'en',
         i18n: {
           defaultLocale: 'de',
           locales: ['de', 'en-US', 'de-DE'],
@@ -543,42 +544,6 @@ describe('serverSideTranslations', () => {
         },
       },
     })
-  })
-
-  it('calls reloadResources when reloadOnPrerender option is true', async () => {
-    renderDummyComponent()
-
-    if (globalI18n) {
-      globalI18n.reloadResources = jest.fn()
-    }
-
-    await serverSideTranslations('en-US', [], {
-      i18n: {
-        defaultLocale: 'en-US',
-        locales: ['en-US', 'fr-CA'],
-      },
-      reloadOnPrerender: true,
-    } as UserConfig)
-
-    expect(globalI18n?.reloadResources).toHaveBeenCalledTimes(1)
-  })
-
-  it('does not call reloadResources when reloadOnPrerender option is false', async () => {
-    renderDummyComponent()
-
-    if (globalI18n) {
-      globalI18n.reloadResources = jest.fn()
-    }
-
-    await serverSideTranslations('en-US', [], {
-      i18n: {
-        defaultLocale: 'en-US',
-        locales: ['en-US', 'fr-CA'],
-      },
-      reloadOnPrerender: false,
-    } as UserConfig)
-
-    expect(globalI18n?.reloadResources).toHaveBeenCalledTimes(0)
   })
 
   it('throws if a function is used for localePath and namespaces are not provided', async () => {

--- a/src/serverSideTranslations.ts
+++ b/src/serverSideTranslations.ts
@@ -4,8 +4,6 @@ import path from 'path'
 import { createConfig } from './config/createConfig'
 import createClient from './createClient/node'
 
-import { globalI18n } from './appWithTranslation'
-
 import { UserConfig, SSRConfig } from './types'
 import { getFallbackForLng, unique } from './utils'
 import { Module, Namespace } from 'i18next'
@@ -62,12 +60,7 @@ export const serverSideTranslations = async (
     localeExtension,
     localePath,
     fallbackLng,
-    reloadOnPrerender,
   } = config
-
-  if (reloadOnPrerender) {
-    await globalI18n?.reloadResources()
-  }
 
   const { i18n, initPromise } = createClient({
     ...config,


### PR DESCRIPTION
Ensure serverSideTranslations do not rely on a global state.

When working with Next.js apps using the app router, we need a clear distinction between the server and client code. On server, we don't need global state, because we won't change it later.